### PR TITLE
install: add explicit sudo to tasks where necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,21 @@ See the following Ansible variable files for more settings that can be configure
 - `vars/Ubuntu-14.04.yml` - contains the defaults for variables specific to PostgreSQL running on Ubuntu 14.04.
 - `vars/Ubuntu.yml` - contains the defaults for variables specific to PostgreSQL running on Ubuntu (any version of Ubuntu).
 
+#### Testing
+
+##### Local tests
+
+A Vagrantfile has been included with this project to provision two (2) virtual machines with the Ansible role using some test data. One virtual machine will install and configure PostgreSQL version 9.3 and the other, version 9.4. Please execute the `vagrant up` command create these virtual machines.
+
+To destroy the Vagrant virtual machines after the provisioning process is complete, execute `vagrant destroy` and follow the prompts.
+
+##### Automated tests
+
+Automated tests to check the correctness of the Ansible playbook syntax and the idempotency of the role are executed after a commit to GitHub. These automated tests are performed by [Travis CI](https://travis-ci.org/). Both the PostgreSQL version 9.3 and 9.4 cases are tested.
+
 #### Notes
 
-Both PostgreSQL version 9.3 and PostgreSQL 9.4 are supported and tested by this role. When `vagrant up` is run in the repository root, two Vagrant VMs will be provisioned - one with a PostgreSQL 9.3 cluster and the other with a PostgreSQL 9.4 cluster. The automated Travis CI tests will also test PostgreSQL version 9.3 and PostreSQL version 9.4.
+None.
 
 #### License
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,6 @@ Vagrant.configure('2') do |config|
         postgresql_version: 9.4
       }
       ansible.verbose = 'vv'
-      ansible.sudo = true
       ansible.inventory_path = 'vagrant-inventory'
       ansible.host_key_checking = false
     end
@@ -36,7 +35,6 @@ Vagrant.configure('2') do |config|
         postgresql_version: 9.3
       }
       ansible.verbose = 'vv'
-      ansible.sudo = true
       ansible.inventory_path = 'vagrant-inventory'
       ansible.host_key_checking = false
     end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,13 +1,15 @@
 ---
 
-# General settings.
+#------------------------------------------------------------------------------
+# GENERAL
+#------------------------------------------------------------------------------
+
 postgresql_encoding: 'UTF-8'
 postgresql_locale: 'en_US.UTF-8'
 
 postgresql_admin_role: "postgres"
 postgresql_default_auth_method: "trust"
 
-# Operating system-level user/group that will run the postgresql process or service.
 postgresql_service_user: "{{ postgresql_admin_role }}"
 postgresql_service_group: "{{ postgresql_admin_role }}"
 
@@ -18,13 +20,10 @@ postgresql_database_owner: "{{ postgresql_admin_role }}"
 postgresql_ext_install_contrib: no
 postgresql_ext_install_dev_headers: yes
 
-# List of databases to be created (optional).
 postgresql_databases: []
 
-# List of roles to be created (optional).
 postgresql_roles: []
 
-# List of role privileges to be applied (optional).
 postgresql_role_privileges: []
 
 #------------------------------------------------------------------------------

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,4 @@
   service:
     name: postgresql
     state: restarted
+  sudo: yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -29,6 +29,7 @@
     group: "{{ postgresql_service_group }}"
     mode: 0640
   register: postgresql_hba_configuration
+  sudo: yes
 
 - name: Create the PostgreSQL settings configuration file (postgresql.conf)
   template:
@@ -38,6 +39,7 @@
     group: "{{ postgresql_service_group }}"
     mode: 0640
   register: postgresql_settings_configuration
+  sudo: yes
 
 - name: Create directory for additional PostgreSQL application configuration files
   file:
@@ -46,9 +48,11 @@
     owner: "{{ postgresql_service_user }}"
     group: "{{ postgresql_service_group }}"
     mode: 0755
+  sudo: yes
 
 - name: Restart the PostgreSQL process or service
   service:
     name: postgresql
     state: restarted
+  sudo: yes
   when: postgresql_hba_configuration.changed or postgresql_settings_configuration.changed

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -4,6 +4,7 @@
   service:
     name: postgresql
     state: started
+  sudo: yes
 
 - name: Create the provided PostgreSQL databases
   postgresql_db:

--- a/tasks/install/Ubuntu.yml
+++ b/tasks/install/Ubuntu.yml
@@ -5,11 +5,13 @@
     id: "{{ postgresql_apt_key_id }}"
     url: "{{ postgresql_apt_key_url }}"
     state: present
+  sudo: yes
 
 - name: Add the official PostgreSQL repository to the system
   apt_repository:
     repo: "{{ postgresql_apt_repository }}"
     state: present
+  sudo: yes
 
 - name: Install PostgreSQL dependency packages
   apt:
@@ -20,6 +22,7 @@
   with_items:
     - python-psycopg2
     - python-pycurl
+  sudo: yes
 
 - name: Install PostgreSQL packages
   apt:
@@ -32,6 +35,7 @@
     - "postgresql-{{ postgresql_version }}"
     - "postgresql-client-{{ postgresql_version }}"
     - "postgresql-contrib-{{ postgresql_version }}"
+  sudo: yes
 
 - name: Install the PostgreSQL contrib extensions
   apt:
@@ -42,6 +46,7 @@
   notify:
     - restart postgresql
   when: postgresql_ext_install_contrib
+  sudo: yes
 
 - name: Install the PostgreSQL development headers
   apt:
@@ -52,3 +57,4 @@
   notify:
     - restart postgresql
   when: postgresql_ext_install_dev_headers
+  sudo: yes

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -4,6 +4,7 @@
   service:
     name: postgresql
     state: started
+  sudo: yes
 
 - name: Add the provided roles to the PostgreSQL instance
   postgresql_user:


### PR DESCRIPTION
Add explicit sudo instructions on plays which
require them, remove 'ansible.sudo=yes' from
the Vagrantfile, add local and automated testing
information to the README.md file.

Fixes #2