### PR TITLE
docs: change 'pass' key name to 'password'

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Example:
 ```
 postgresql_roles:
   - name: adamjcook
-    pass: Password1
+    password: Password1
 ```
 
 - `postgresql_role_privileges` - a list of YAML dictionaries describing the database where the privileges and any role attributes will be granted.


### PR DESCRIPTION
Change the 'pass' key name to 'password' as
documented in the README.md file for the
'postgresql_roles' variable as 'pass' is
incorrect and, if used, will result in role
execution failure.

Fixes #9