### PR TITLE
test: add test values for creating roles and databases

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -27,6 +27,9 @@
   sudo_user: "{{ postgresql_service_user }}"
   shell: "psql {{ item.name }} --username {{ postgresql_admin_role }} -c 'CREATE EXTENSION IF NOT EXISTS hstore;'"
   with_items: postgresql_databases
+  register: hstore_ext_result
+  failed_when: hstore_ext_result.rc != 0 and ("already exists, skipping" not in hstore_ext_result.stderr)
+  changed_when: hstore_ext_result.rc == 0 and ("already exists, skipping" not in hstore_ext_result.stderr)
   when: item.hstore is defined and item.hstore
 
 - name: Add the uuid-ossp extension to the PostgreSQL databases

--- a/test_vars.yml
+++ b/test_vars.yml
@@ -1,3 +1,15 @@
 ---
 
 postgresql_version: '9.4'
+postgresql_databases:
+  - name: 'accounting_db'
+    hstore: yes
+    uuid_ossp: yes
+postgresql_roles:
+  - name: 'adamjcook'
+    password: 'Password1'
+postgresql_role_privileges:
+  - role: 'adamjcook'
+    database: 'accounting_db'
+    privileges: 'ALL'
+    role_attr_flags: 'CREATEDB'


### PR DESCRIPTION
Add test values for the 'postgresql_databases',
'postgresql_roles' and 'postgresql_role_privileges'
Ansible variables to verify idempotency on subsequent
playbook runs.

Fixes #10